### PR TITLE
HW №7

### DIFF
--- a/kubernetes-operators/clusterrole-min-needed.yaml
+++ b/kubernetes-operators/clusterrole-min-needed.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-server-admin
+rules:
+  - apiGroups:
+      - "otus.homework"
+    resources:
+      - "mysqls"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - "services"
+      - "persistentvolumes"
+      - "persistentvolumeclaims"
+    verbs:
+      - "create"
+      - "patch"
+      - "update"
+      - "delete"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "create"
+      - "patch"
+      - "update"
+      - "delete"

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  scope: Namespaced
+  group: otus.homework
+  names:
+    plural: mysqls
+    singular: mysql
+    kind: MySQL
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string

--- a/kubernetes-operators/deployment.yaml
+++ b/kubernetes-operators/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hw-7
+  labels:
+    app: hw-7
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hw-7
+  template:
+    metadata:
+      labels:
+        app: hw-7
+    spec:
+      containers:
+      - name: mysql
+        image: roflmaoinmysoul/mysql-operator:1.0.0
+      serviceAccountName: api-server-admin

--- a/kubernetes-operators/mysql.yaml
+++ b/kubernetes-operators/mysql.yaml
@@ -1,0 +1,9 @@
+apiVersion: "otus.homework/v1"
+kind: MySQL
+metadata:
+  name: mysql
+spec:
+  image: mysql
+  database: ahalay
+  password: mahalay
+  storage_size: 1Gi

--- a/kubernetes-operators/namespace.yaml
+++ b/kubernetes-operators/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+  labels:
+    name: homework

--- a/kubernetes-operators/namespace.yaml
+++ b/kubernetes-operators/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: homework
-  labels:
-    name: homework

--- a/kubernetes-operators/service-account.yaml
+++ b/kubernetes-operators/service-account.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-server-admin
+  namespace: homework
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-server-admin
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: api-server-admin
+subjects:
+- kind: ServiceAccount
+  name: api-server-admin
+  namespace: homework
+roleRef:
+  kind: ClusterRole
+  name: api-server-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/service-account.yaml
+++ b/kubernetes-operators/service-account.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: api-server-admin
-  namespace: homework
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -17,10 +16,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: api-server-admin
+  namespace: default
 subjects:
 - kind: ServiceAccount
   name: api-server-admin
-  namespace: homework
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: api-server-admin


### PR DESCRIPTION
# Выполнено ДЗ №7

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - создан манифесты для CRD, сервисного аккаунта (с ролью и привязкой аккаунта к роли) и роли с минимальным набором прав согласно методическим указаниям по ДЗ.

## Как запустить проект:
Основное задание:
```
kubectl apply -f crd.yaml
kubectl apply -f service-account.yaml
kubectl apply -f deployment.yaml
kubectl apply -f mysql.yaml
```
Задание с * **(строго после выполнения основного задания)**:
`kubectl apply -f clusterrole-min-needed.yaml`

## Как проверить работоспособность:
Все пункты актуальны как для основного задания, так и для задания с *.
 - `kubectl get customresourcedefinition`
 ожидаемый вывод:
```
NAME                   CREATED AT
mysqls.otus.homework   ..........
```
- `kubectl get serviceaccount`
 ожидаемый вывод:
```
NAME               SECRETS   AGE
api-server-admin   0         ...
default            0         ...
```
- `kubectl get clusterrole`
 ожидаемый вывод:
```
NAME                CREATED AT
..............................
api-server-admin     .........
..............................
```
- `kubectl get clusterrolebinding`
 ожидаемый вывод:
```
NAME                 ROLE                             AGE
.........................................................
api-server-admin     ClusterRole/api-server-admin     ...
.........................................................
```
- `kubectl get deployment`
 ожидаемый вывод:
```
NAME    READY   UP-TO-DATE   AVAILABLE   AGE
hw-7    1/1     1            1           ...
mysql   1/1     1            1           ...
```
- `kubectl get pod`
 ожидаемый вывод:
```
NAME                     READY   STATUS    RESTARTS   AGE
hw-7-xxxxxxxxxx-aaaaa    1/1     Running   0          ...
mysql-yyyyyyyyyy-bbbbb   1/1     Running   0          114s
```
- `kubectl get service`
ожидаемый вывод:
```
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
kubernetes   ClusterIP   xx.yy.z.a    <none>        443/TCP    ...
mysql        ClusterIP   None         <none>        3306/TCP   ...
```
- `kubectl get persistentvolume`
ожидаемый вывод:
```
NAME       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM               STORAGECLASS   REASON   AGE
mysql-pv   1Gi        RWO            Retain           Bound    default/mysql-pvc   standard                ...
```
- `kubectl get persistentvolumeclaim`
ожидаемый вывод:
```
NAME        STATUS   VOLUME     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-pvc   Bound    mysql-pv   1Gi        RWO            standard       ...
```
- 
```
kubectl delete mysql mysql
kubectl get deployment
kubectl get pod
kubectl get service
kubectl get persistentvolume
kubectl get persistentvolumeclaim
```
ожидаемый вывод: отсутствуют объекты mysqlxxx.